### PR TITLE
Updates for phantomjs 1.9.x?

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,13 +27,13 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "phantomjs": ">= 0.2.0"
+    "phantomjs": "^1.9.16"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.6.0",
     "grunt-contrib-clean": "~0.4.0",
     "grunt-contrib-nodeunit": "~0.2.0",
-    "grunt": "~0.4.2"
+    "grunt": "^0.4.5"
   },
   "keywords": [
     "gruntplugin",

--- a/tasks/lib/involvePhantom.js
+++ b/tasks/lib/involvePhantom.js
@@ -3,13 +3,14 @@
 var path = require("path");
 var execFile = require("child_process").execFile;
 
-var phantomjsCmd = path.resolve(__dirname, "../../node_modules/phantomjs/bin/phantomjs");
+var phantomjs    = require('phantomjs')
+var phantomjsCmd = phantomjs.path;
 var converterFileName = path.resolve(__dirname, "./snapshot.js");
 
 module.exports = function snapshot(grunt, file, dest, callback) {
     // is that correct, can I only pass strings as arguments?
-    var args = [phantomjsCmd, converterFileName, file.src, file.dest, dest.name, dest.width, dest.height];
-    execFile(process.execPath, args, function (err, stdout, stderr, grunt) {
+    var args = [converterFileName, file.src, file.dest, dest.name, dest.width, dest.height];
+    execFile(phantomjsCmd, args, function (err, stdout, stderr) {
         if (err) {
             callback(err);
         } else if (stdout.length > 0) { // PhantomJS always outputs to stdout.

--- a/tasks/vector2raster.js
+++ b/tasks/vector2raster.js
@@ -16,10 +16,23 @@ module.exports = function(grunt) {
 
   grunt.registerMultiTask('vector2raster', 'Convert svg to (multiple) (resized) raster images', function() {
 
+        var done = this.async();
         var dest, opts = this.options();
+        var count = 1;
+        var error = false;
 
+        var deCount = function() {
+          --count;
+          if (count === 0) {
+            done(!error);
+          }
+        };
         var callback = function(err){
-            console.log(err);
+            if (err) {
+              error = true;
+              console.error(err);
+            }
+            deCount();
         };
 
         this.files.forEach(function(file) {
@@ -46,10 +59,12 @@ module.exports = function(grunt) {
                 }
  
               };
+              ++count;
               involvePhantom(grunt, file, dest, callback);
           });
 
         });
+        deCount();
   });
 
 };


### PR DESCRIPTION
This must have worked for you when you checked it in
but it doesn't seem to work now.

execFile is not sync as it has a callback. That means grunt,
at least current grunt, just exits before the phantomjs continues.

To handle that I needed to add `var done = this.async();` to tell
grunt the rules async and then keep a count and call `done` when
all the images have been processed.

On top of that `child_process.execFile` takes a path to phantomjs
but the code was passing in a path to node. Maybe that's how it
used to work?

Also the current phantomjs provides a path to the exec.

Anyway, with those changes it works for me.